### PR TITLE
Enhance ebash to function properly as top-level shebang.

### DIFF
--- a/bin/ebash
+++ b/bin/ebash
@@ -125,7 +125,7 @@ else
 
             SOURCE="${1}"
             SCRIPT=$(mktemp --tmpdir ebash-script-XXXXXX)
-            trap_add "rm ${SCRIPT}"
+            trap_add "rm -f ${SCRIPT}"
 
             cp "${SOURCE}" "${SCRIPT}"
             sed -i -e "s%^#!.*%source ${EBASH}/ebash.sh || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }%" "${SCRIPT}"

--- a/bin/ebash
+++ b/bin/ebash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -21,7 +21,7 @@
 # to run ebash functions intead.  First, it looks to see if the symlink
 # name is the name of a "namespace" of ebash commands.  For instance, the
 # string commands can be used in this way.  Assuming a "string" symlink, then
-#    
+#
 #     string trim " a string to trim "
 #
 # will call the string_trim function, passing it that string as an argument.
@@ -79,7 +79,7 @@ if [[ ${name} == "ebash" ]] ; then
     $(opt_parse \
         ":load l          | ebash should source the specified file before attempting to run the specified command." \
         "+source s        | Print commands that would load ebash from its existing location on disk into the current
-                            shell and then exit.  You'd use this in a script like this: \$(ebash --load)" \
+                            shell and then exit.  You'd use this in a script like this: \$(ebash --source)" \
         "+print_environment printenv p | Dump environment variables that ebash would like to use in a format bash
                             can interpret" \
         ":name n=${0##*/} | Name to use as a starting point for finding functions.  I.e pretend ebash is running
@@ -90,7 +90,7 @@ if [[ ${name} == "ebash" ]] ; then
     fi
 
     if [[ ${source} -eq 1 ]] ; then
-        echo "eval export EBASH=${EBASH} EBASH_HOME=${EBASH_HOME} ; source \"${EBASH}/ebash.sh\" || { echo \"Unable to source ${EBASH}/bashtuils.sh\" ; exit 1 ; }"
+        echo "eval export EBASH=${EBASH} EBASH_HOME=${EBASH_HOME} ; source \"${EBASH}/ebash.sh\" || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }"
         exit 0
     elif [[ ${print_environment} -eq 1 ]] ; then
         printf "export EBASH=%q\n" "${EBASH}"
@@ -102,14 +102,12 @@ fi
 # If not called as ebash...
 if [[ "${name}" != "ebash" ]] ; then
 
-    # If there's a function in the group with the specified command name call
-    # it
+    # If there's a function in the group with the specified command name call it
     if [[ -n ${1:-} ]] && declare -f "${name}_${1}" &>/dev/null ; then
 
         quote_eval "${name}_${1}" "${@:2}"
 
-    # Otherwise assume the called name is also the name of a ebash function
-    # and pass everything as arguments to it.
+    # Otherwise assume the called name is also the name of a ebash function and pass everything as arguments to it.
     else
         quote_eval "${name}" "${@:1}"
     fi
@@ -119,13 +117,29 @@ else
 
     # Use all arguments to ebash as a command to execute
     if [[ ${#@} -gt 0 ]] ; then
-        # Run the command, but pretend to be inside a try so that die doesn't
-        # print an ugly stack trace.
+
+        # If we were given the path to another script run it inside ebash environment
+        if [[ ${#@} -eq 1 && -e "${1}" ]]; then
+
+            export EBASH EBASH_HOME
+
+            SOURCE="${1}"
+            SCRIPT=$(mktemp --tmpdir etest-script-sh-XXXXXX)
+            trap_add "rm ${SCRIPT}"
+
+            cp "${SOURCE}" "${SCRIPT}"
+            sed -i -e "s%^#!.*%source ${EBASH}/ebash.sh || { echo \"Unable to source ${EBASH}/ebash.sh\" ; exit 1 ; }%" "${SCRIPT}"
+            chmod +x "${SCRIPT}"
+
+            exec "${SCRIPT}"
+        fi
+
+        # Run the command, but pretend to be inside a try so that die doesn't print an ugly stack trace.
         quote_eval "${@}"
 
-    # Or run ibu if nothing was specified
+    # Or run iebash if nothing was specified
     else
-        exec ${EBASH_HOME}/bin/ibu --load "${load}"
+        exec ${EBASH_HOME}/bin/iebash --load "${load}"
     fi
 
 fi

--- a/bin/ebash
+++ b/bin/ebash
@@ -124,7 +124,7 @@ else
             export EBASH EBASH_HOME
 
             SOURCE="${1}"
-            SCRIPT=$(mktemp --tmpdir etest-script-sh-XXXXXX)
+            SCRIPT=$(mktemp --tmpdir ebash-script-XXXXXX)
             trap_add "rm ${SCRIPT}"
 
             cp "${SOURCE}" "${SCRIPT}"

--- a/bin/iebash
+++ b/bin/iebash
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
 # as published by the Apache Software Foundation, either version 2 of the License, or (at your option) any later
 # version.
 
-# Allow calling function documentation in ibu.  This must happen before
-# sourcing ebash.
+# Allow calling function documentation in ebash. This must happen before sourcing ebash.
 __EBASH_SAVE_DOC=1
 
 reload()
@@ -24,7 +23,7 @@ reload
 HISTFILE=$(mktemp --tmpdir iebash_$$_XXXXXX)
 trap_add "rm --force \"${HISTFILE}\""
 
-: ${IBU_PROMPT:=$(ecolor green)$'IBU>\n'$(ecolor none)}
+: ${EBASH_PROMPT:=$(ecolor bold green)$'EBASH> '$(ecolor none)}
 
 # Trap SIGINT during read in such a way that Ctrl-C
 #    1) doesn't blow us up
@@ -49,7 +48,7 @@ repl()
         # Note: In typical ebash style, I would probably use tryrc here,
         # but I want to make sure that all commands are executed in the same
         # shell.
-        protected_read -e -r -p "${IBU_PROMPT}" cmd && rc=0 || rc=$?
+        protected_read -e -r -p "${EBASH_PROMPT}" cmd && rc=0 || rc=$?
 
         edebug "$(lval rc cmd)"
         if [[ ${rc} -eq 1 ]] ; then

--- a/changelog.md
+++ b/changelog.md
@@ -11,10 +11,10 @@
     - New dialog.sh module provides a simple interface for using dialog
       ncurses interface (http://invisible-island.net/dialog/) within bash.
       This module provides some convenience wrappers to make it easier to
-      obtain the output from dialog and its return code without without 
+      obtain the output from dialog and its return code without without
       causing the ERR trap to be invoked via the "eval command invocation
       string" idiom. Also provides convenience methods dialog_read,
-      dialog_prompt, dialog_prgbox, dialog_prompt_username_password and a 
+      dialog_prompt, dialog_prgbox, dialog_prompt_username_password and a
       very large set of unit tests around this new module. At this time
       there are some bugs with dialog on older Ubuntu 12.04 and also on
       OSX so the module is excluded from those OSes.
@@ -150,7 +150,7 @@
 
     - Readme and unit tests are now included in the package.
 
-    - Revamp overlayfs module to to perform all parsing of the various mount 
+    - Revamp overlayfs module to to perform all parsing of the various mount
       layers into a single overlayfs_layers function. This uses a pack to more
       easily and consistently access various mount points and sources of the
       mount points throughout overlayfs code.
@@ -193,7 +193,7 @@
       Provides great tools for mounting, unmounting, listing, saving and
       printing out tree representation.
 
-    - Consolidated eunmount_recursive, eunmount_rm and eunmount into a 
+    - Consolidated eunmount_recursive, eunmount_rm and eunmount into a
       single function with flags to control its behavior. This single function
       can now optionally unmount recursively and also optionally remove the
       mount point (recursively) if desired. It also has the ability to continue

--- a/unittest/process.etest
+++ b/unittest/process.etest
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com> 
+# Copyright 2011-2018, Marshall McMullen <marshall.mcmullen@gmail.com>
 # Copyright 2011-2018, SolidFire, Inc. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the Apache License
@@ -250,7 +250,7 @@ ETEST_process_parent_tree()
     {
         "pid": 17389,
         "ppid": 2895,
-        "cmd": "bash bin/ibu"
+        "cmd": "bash bin/iebash"
     }
 ]
 EOM
@@ -260,7 +260,7 @@ EOM
 (    1)* /sbin/init splash
 (25473) * tmux -u -2 -f /usr/share/byobu/profiles/tmuxrc new-session
 ( 2895)  * /bin/bash
-(17389)   * bash bin/ibu
+(17389)   * bash bin/iebash
 EOM
 )
     ps()


### PR DESCRIPTION
This enhances ebash so that it can function as actual shebang. e.g. instead of the old:

```
#!/usr/bin/env bash

$(ebash --source)

<rest of script>
```

You can now simply say:

```
#!/usr/bin/env ebash

<rest of script>
```
